### PR TITLE
Improving segment snapping: polygon parts are now converted to polylines

### DIFF
--- a/src/COM classes/ShapeEditor.cpp
+++ b/src/COM classes/ShapeEditor.cpp
@@ -1252,6 +1252,7 @@ void CShapeEditor::HandleProjPointAdd(double projX, double projY)
 	double pixelX, pixelY;
 	_mapCallback->_ProjectionToPixel(projX, projY, &pixelX, &pixelY);
 	_activeShape->AddPoint(projX, projY, pixelX, pixelY);
+	_activeShape->ClearSnapPoint();
 }
 
 // ***************************************************************

--- a/src/Control/Map_Drawing.cpp
+++ b/src/Control/Map_Drawing.cpp
@@ -1226,9 +1226,9 @@ bool CMapView::HasDrawingData(tkDrawingDataAvailable type)
 			}
 		case ActShape:	
 			{
-				VARIANT_BOOL isEmpty;
-				_shapeEditor->get_IsEmpty(&isEmpty);
-				return !isEmpty ? true : false;
+				/*VARIANT_BOOL isEmpty;
+				_shapeEditor->get_IsEmpty(&isEmpty);*/
+				return true; // !isEmpty ? true : false;  always draw this to clear snap points
 			}	
 		case ZoomBox:
 			{
@@ -1238,7 +1238,7 @@ bool CMapView::HasDrawingData(tkDrawingDataAvailable type)
 			{
 				if (!GetEditorBase()->GetCreationMode())
 					return false;
-				return GetEditorBase()->GetPointCount() > 0;
+				return true; // GetEditorBase()->GetPointCount() > 0; always draw this to show snap points
 			}
 		case tkDrawingDataAvailable::LayersData:	
 			{

--- a/src/Control/Map_Edit.cpp
+++ b/src/Control/Map_Edit.cpp
@@ -91,7 +91,7 @@ bool CMapView::HandleOnMouseMoveShapeEditor(int x, int y, long nFlags)
 	else {
         double sX, sY;
         ProjToPixel(projX, projY, &sX, &sY);
-        GetEditorBase()->SetSnapPoint(sX, sY, true);
+        GetEditorBase()->SetSnapPoint(sX, sY);
     }
 		
 

--- a/src/Control/Map_Events.cpp
+++ b/src/Control/Map_Events.cpp
@@ -1245,20 +1245,22 @@ void CMapView::OnMouseMove(UINT nFlags, CPoint point)
 	if ((EditorHelper::IsDigitizingCursor((tkCursorMode)m_cursorMode) || m_cursorMode == cmMeasure))
 	{
 		ActiveShape* shp = GetActiveShape();
+
+		VARIANT_BOOL snapped = VARIANT_FALSE;
+		double x = point.x, y = point.y;
+		if (SnappingIsOn(nFlags))
+		{
+			if (this->FindSnapPointCore(point.x, point.y, &x, &y)) {
+				ProjToPixel(x, y, &x, &y);
+				GetEditorBase()->SetSnapPoint(x, y);
+			}
+			else {
+				GetEditorBase()->ClearSnapPoint();
+			}
+		}
+
 		if (shp->IsDynamic() && shp->GetPointCount() > 0)
 		{
-			VARIANT_BOOL snapped = VARIANT_FALSE;
-			double x = point.x, y = point.y;
-			if (SnappingIsOn(nFlags))
-			{
-				snapped = this->FindSnapPointCore(point.x, point.y, &x, &y);
-				if (snapped) {
-					ProjToPixel(x, y, &x, &y);
-					_shapeEditor->GetActiveShape()->SetSnapPoint(x, y, true);
-				}
-				else
-					_shapeEditor->GetActiveShape()->ClearSnapPoint();
-			}
 			shp->SetMousePosition(x, y);
 			refreshNeeded = true;
 		}

--- a/src/Editor/ActiveShape.cpp
+++ b/src/Editor/ActiveShape.cpp
@@ -133,7 +133,7 @@ void ActiveShape::DrawData( Gdiplus::Graphics* g, bool dynamicBuffer,
 {
 	bool hasLine = HasLine(dynamicBuffer);
 	bool hasPolygon = HasPolygon(dynamicBuffer); 
-	if (!hasLine && !hasPolygon) return;
+	if (!hasLine && !hasPolygon && !_showSnapPoint) return;
 
 	_fillBrush.SetColor(Utility::OleColor2GdiPlus(FillColor, FillTransparency)) ;
 	_linePen.SetWidth(LineWidth);

--- a/src/Editor/EditorBase.cpp
+++ b/src/Editor/EditorBase.cpp
@@ -69,6 +69,7 @@ bool EditorBase::SnapToPreviousVertex(int& vertexIndex, double screenX, double s
 void EditorBase::Clear()
 {
 	SetShapeType(SHP_NULLSHAPE);
+	ClearSnapPoint();
 	ActiveShape::Clear();
 }
 
@@ -84,7 +85,7 @@ bool EditorBase::ClearHighlightedVertex()
 	return false;
 }
 
-void EditorBase::SetSnapPoint(double x, double y, bool visible)
+void EditorBase::SetSnapPoint(double x, double y)
 {
 	_snapPointX = x;
 	_snapPointY = y;

--- a/src/Editor/EditorBase.h
+++ b/src/Editor/EditorBase.h
@@ -39,7 +39,7 @@ public:
 	bool SetSelectedVertex(int index);
 	bool ClearHighlightedPart();
 	bool ClearHighlightedVertex();
-	void SetSnapPoint(double x, double y, bool visible);
+	void SetSnapPoint(double x, double y);
 	void ClearSnapPoint();
 	int SelectPart(double xProj, double yProj);
 	int GetClosestVertex(double projX, double projY, double tolerance);


### PR DESCRIPTION
Hi there!

I've improved the snapping algorithm a little bit. Previously when drawing features on top of a polygon, the snap point would never 'snap' to features inside the polygon or even the contours of the polygon. This was because the test was to find the closest point from the cursor to a shape near the cursor. Since the cursor was inside a polygon, the closest point equaled the cursor position.

The fix was not to use the polygon as such, but convert it's edges into polylines and use those polylines to snap to.

Additional changes include making the snap point always visible. Previously when starting a new shape (and holding shift or setting the snap mode) the snapped-to point was not indicated on the map (red square). Only after the first point was added (which was still correctly snapped) the snap point was indicated.


tell me what you think
