### PR TITLE
Change default value for the bForce flag of the get_Extents call to V…

### DIFF
--- a/src/COM classes/OgrLayer.cpp
+++ b/src/COM classes/OgrLayer.cpp
@@ -40,7 +40,7 @@ void COgrLayer::InitOpenedLayer()
 	get_FeatureCount(VARIANT_FALSE, &featureCount);
 	
 	CComPtr<IExtents> extents = NULL;
-	get_Extents(&extents, VARIANT_FALSE, &vb);
+	get_Extents(&extents, VARIANT_TRUE, &vb);
 
 	if (m_globalSettings.autoChooseOgrLoadingMode) {
 		long maxCount;


### PR DESCRIPTION
…ARIANT_TRUE in InitOpenedLayer

This fixes dynamic loading for OGR database drivers that do not override the default implementation of GetExtents calls.