### PR TITLE
fixed disappering tiles on zoom 1-3

### DIFF
--- a/src/Tiles/Projections/BaseProjection.h
+++ b/src/Tiles/Projections/BaseProjection.h
@@ -91,7 +91,7 @@ public:
 	void GetTileMatrixSizeXY(int zoom, CSize &ret);
 	void getTileRectXY(Extent extentsWgs84, int zoom, CRect &rect);
 
-	RectLatLng CalculateGeogBounds(CPoint pnt, int zoom);
+	virtual RectLatLng CalculateGeogBounds(CPoint pnt, int zoom);
 
 	void Clip(CPoint& tilePnt, int zoom);
 

--- a/src/Tiles/Projections/MercatorProjection.cpp
+++ b/src/Tiles/Projections/MercatorProjection.cpp
@@ -117,3 +117,35 @@ void MercatorProjection::FromXYToLatLng(CPoint pnt, int zoom, PointLatLng &ret)
 	ret.Lng = 360 * xx;
 }
 
+// ****************************************************
+//		CalculateGeogBounds
+// ****************************************************
+// check result from BaseProjection against min/max lat/lon, because BaseProjection don't 
+// have lat/lon limits, but Mercator do
+RectLatLng MercatorProjection::CalculateGeogBounds(CPoint pnt, int zoom)
+{
+	auto res = BaseProjection::CalculateGeogBounds(pnt, zoom);
+
+	//sanity check
+
+	if (res.yLat > _maxLat)
+		res.yLat = _maxLat;
+
+	if (res.yLat < _minLat)
+		res.yLat = _minLat;
+
+	if (res.xLng > _maxLng)
+		res.xLng = _maxLng;
+
+	if (res.xLng < _minLng)
+		res.xLng = _minLng;
+
+	if ((res.xLng + res.WidthLng) > _maxLng)
+		res.WidthLng = _maxLng - res.xLng;
+
+	if ((res.yLat - res.HeightLat) < _minLat)
+		res.HeightLat = res.yLat - _minLat;
+
+	return res;
+}
+

--- a/src/Tiles/Projections/MercatorProjection.h
+++ b/src/Tiles/Projections/MercatorProjection.h
@@ -60,4 +60,6 @@ public:
 	// converts tile coordinates to decimal degrees
 	void FromXYToLatLng(CPoint pnt, int zoom, PointLatLng &ret);
 	
+	// override BaseProjection's member to check result
+	virtual RectLatLng CalculateGeogBounds(CPoint pnt, int zoom);
 };


### PR DESCRIPTION
Tile bounds calculated `BaseProjection::CalculateGeogBounds` can overlap projection limits, causing GDAL error and tile disappearing. Take world map for example: we have tile grid 4*4 on zoom level 2, tile height (lat) will be ~18, 66, 66, 18. But for lower tile row `BaseProjection` returns top lat -66 and height 66, which causes to transform via OGRCoordinateTransformation::transform latitudes like -133 (-66 - 66, top lat - height) and GDAL error. I'm not able to understand, why this doesn't happens with top tiles row (why `BaseProjection` calculates right height 18 for them), but able to patch it around overriding `BaseProjection::CalculateGeogBounds` in `MercatorProjection::CalculateGeogBounds` and checking calculated tile bounds against min/max lat/lon.

That's vanilla MapWindow:
![error](https://user-images.githubusercontent.com/14928699/69870687-c5846e00-12c1-11ea-8964-a5abc95d202f.gif)

Again, with fix:
![fixed](https://user-images.githubusercontent.com/14928699/69870643-a08ffb00-12c1-11ea-95da-380b83b078ec.gif)