### PR TITLE
WMS BoundingBox Order

### DIFF
--- a/src/MapWinGIS.idl
+++ b/src/MapWinGIS.idl
@@ -85,6 +85,19 @@ enum tkWmsVersion {
 	wv13 = 5,
 } tkWmsVersion;
 
+/************************** tkWmsBoundingBoxOrder Enumeration **********************/
+typedef
+[
+	uuid(A61764EF-141E-4BBF-A719-DE93E780B2A5),
+	helpstring("tkWmsBoundingBoxOrder"),
+]
+enum tkWmsBoundingBoxOrder
+{
+	bboAuto = 0,
+	bboLongLat = 1,
+	bboLatLong = 2,
+} 	tkWmsBoundingBoxOrder;
+
 /************************** tkCallbackVerbosity Enumeration **********************/
 typedef
 [

--- a/src/Tiles/Providers/RosreestrProvider.h
+++ b/src/Tiles/Providers/RosreestrProvider.h
@@ -32,7 +32,7 @@ public:
 	{
 		Id = tkTileProvider::Rosreestr;
 		Name = "Rosreestr";
-		_copyright = "©Росреестр";
+		_copyright = "©?in?aano?";
 		_serverLetters = "abc";
 		_licenseUrl = "http://maps.rosreestr.ru/PortalOnline/terms.html";
 		_refererUrl = "http://maps.rosreestr.ru/";
@@ -72,7 +72,7 @@ public:
 
 	CString MakeTileImageUrl(CPoint &pos, int zoom)
 	{
-		CString s = _urlFormat + GetBoundingBox(pos, zoom) + _url2;
+		CString s = _urlFormat + GetBoundingBox(pos, zoom, tkWmsVersion::wvAuto, tkWmsBoundingBoxOrder::bboAuto) + _url2;
 		return s;
 	}
 };

--- a/src/Tiles/Providers/WmsCustomProvider.cpp
+++ b/src/Tiles/Providers/WmsCustomProvider.cpp
@@ -35,7 +35,7 @@ CString WmsCustomProvider::MakeTileImageUrl(CPoint &pos, int zoom)
 	temp.Format("&crs=EPSG:%d", get_CustomProjection()->get_Epsg());
 	s += temp;
 
-	s += "&bbox=" + GetBoundingBox(pos, zoom);
+	s += "&bbox=" + GetBoundingBox(pos, zoom, _version, _bbo);
 	s += "&format=" + _format;
 	s += "&width=256";
 	s += "&height=256";
@@ -62,7 +62,7 @@ CString WmsCustomProvider::get_VersionString()
 	case wv111:
 		return "&version=1.1.1";
 	case wv13:
-		return "&version=1.3";
+		return "&version=1.3.0";
 	default:
 		return "";
 	}

--- a/src/Tiles/Providers/WmsCustomProvider.h
+++ b/src/Tiles/Providers/WmsCustomProvider.h
@@ -31,6 +31,7 @@ public:
 	WmsCustomProvider()
 	{
 		_version = wvAuto;
+		_bbo = bboAuto;
 		_projection = new CustomProjection();
 		_subProviders.push_back(this);
 	}
@@ -42,6 +43,7 @@ private:
 	CString _format;
 	CString _styles;
 	tkWmsVersion _version;
+	tkWmsBoundingBoxOrder _bbo;
 
 public:
 	// properties
@@ -53,6 +55,8 @@ public:
 	void set_Format(CString value) { _format = value; }
 	tkWmsVersion get_Version() { return _version; }
 	void set_Version(tkWmsVersion value) { _version = value; }
+	tkWmsBoundingBoxOrder get_BoundingBoxOrder() { return _bbo; }
+	void set_BoundingBoxOrder(tkWmsBoundingBoxOrder bbo) { _bbo = bbo; }
 	CString get_Styles() { return _styles; }
 	void set_Styles(CString value) { _styles = value; }
 

--- a/src/Tiles/Providers/WmsProviderBase.cpp
+++ b/src/Tiles/Providers/WmsProviderBase.cpp
@@ -24,7 +24,7 @@
  // ******************************************************
  //    GetBoundingBox()
  // ******************************************************
-CString WmsProviderBase::GetBoundingBox(CPoint &pos, int zoom)
+CString WmsProviderBase::GetBoundingBox(CPoint &pos, int zoom, tkWmsVersion version, tkWmsBoundingBoxOrder bbo)
 {
 	PointLatLng pnt1;
 	_projection->FromXYToProj(pos, zoom, pnt1);
@@ -35,11 +35,38 @@ CString WmsProviderBase::GetBoundingBox(CPoint &pos, int zoom)
 	_projection->FromXYToProj(pos, zoom, pnt2);
 
 	CString s;
-	s.Format("%f,%f,%f,%f",
-		MIN(pnt2.Lat, pnt1.Lat),
-		MIN(pnt1.Lng, pnt2.Lng),
-		MAX(pnt1.Lat, pnt2.Lat),
-		MAX(pnt2.Lng, pnt1.Lng));
+
+	if (bbo == tkWmsBoundingBoxOrder::bboAuto)
+	{
+		switch (version)
+		{
+		case wv13:
+			bbo = tkWmsBoundingBoxOrder::bboLongLat;
+		case wvEmpty:
+		case wv100:
+		case wv110:
+		case wvAuto:
+		case wv111:
+		default:
+			bbo = tkWmsBoundingBoxOrder::bboLongLat;
+
+		}
+	}
+
+	if (bbo == tkWmsBoundingBoxOrder::bboLatLong) {
+		s.Format("%f,%f,%f,%f",
+			MIN(pnt2.Lat, pnt1.Lat),
+			MIN(pnt1.Lng, pnt2.Lng),
+			MAX(pnt1.Lat, pnt2.Lat),
+			MAX(pnt2.Lng, pnt1.Lng));
+	}
+	else {
+		s.Format("%f,%f,%f,%f",
+			MIN(pnt1.Lng, pnt2.Lng),
+			MIN(pnt2.Lat, pnt1.Lat),
+			MAX(pnt2.Lng, pnt1.Lng),
+			MAX(pnt1.Lat, pnt2.Lat));
+	}
 
 	return s;
 }

--- a/src/Tiles/Providers/WmsProviderBase.h
+++ b/src/Tiles/Providers/WmsProviderBase.h
@@ -31,7 +31,7 @@ public:
 	virtual ~WmsProviderBase() { }
 
 	// gets bounding box in Google mercator projection (meters; EPSG:3857)
-	virtual CString GetBoundingBox(CPoint &pos, int zoom);
+	virtual CString GetBoundingBox(CPoint &pos, int zoom, tkWmsVersion version, tkWmsBoundingBoxOrder bbo);
 
 	virtual bool IsWms() { return true; }
 };


### PR DESCRIPTION
According to the discussion at https://mapwindow.discourse.group/t/wms-anomaly-in-the-request/426/4 the following adjustments allow to adapt the BoundingBox: Either use tkWMSBoundingBoxOrder or leave it set to Auto, then WMS 1.3.0 uses LongLat