### PR TITLE
Fixed build errors when building with GDAL 3.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ support/GDAL_SDK/**/*.c
 support/GDAL_SDK/**/*.inc
 support/GDAL_SDK/**/*.proto
 support/GDAL_SDK/**/*.pc
+support/temp/
 
 # Custom
 *.dll

--- a/src/COM classes/Utils_GDAL.cpp
+++ b/src/COM classes/Utils_GDAL.cpp
@@ -4342,7 +4342,11 @@ GDALWarpCreateOutput( char **papszSrcFiles, const char *pszFilename,
                      && (pszMethod == NULL || EQUALN(pszMethod,"GCP_",4)) )
                 pszThisSourceSRS = GDALGetGCPProjection( hSrcDS );
             else if( pszMethod != NULL && EQUAL(pszMethod,"RPC") )
-                pszThisSourceSRS = SRS_WKT_WGS84;
+#if GDAL_VERSION_MAJOR >= 3
+                pszThisSourceSRS = SRS_WKT_WGS84_LAT_LONG; //  SRS_WKT_WGS84 macro is no longer declared by default since WKT without AXIS is too ambiguous. Preferred remediation: use SRS_WKT_WGS84_LAT_LONG
+#else
+				pszThisSourceSRS = SRS_WKT_WGS84;
+#endif
             else
                 pszThisSourceSRS = "";
         }

--- a/support/unpackVS2017GISInternals.ps1
+++ b/support/unpackVS2017GISInternals.ps1
@@ -1,0 +1,41 @@
+$zipCount = (Get-ChildItem -Filter release-1911-gdal-*.zip).count
+if ($zipCount -lt 2) {
+    Write-Host "Missing GIS internals zip files."
+    Write-Host "Two zip files are required: compiled binaries and compiled libs and headers."
+    Pause
+    Exit
+}
+if ($zipCount -gt 2) {
+    Write-Host "Too many zip files."
+    Write-Host "Two zip files are required: compiled binaries and compiled libs and headers."
+    Pause
+    Exit
+}
+$zipLibsCount = (Get-ChildItem -Filter release-1911-gdal-*-libs.zip).count
+if ($zipLibsCount -ne 1) {
+    Write-Host "Missing the GIS internals compiled libs and headers zip file."
+    Write-Host "Two zip files are required: compiled binaries and compiled libs and headers."
+    Pause
+    Exit
+}
+
+Get-ChildItem temp\* -Force | Remove-Item -force -recurse
+
+Get-ChildItem -Filter release-1911-gdal-*.zip | Expand-Archive -DestinationPath temp\
+
+Write-Host "Licenses for GIS Internals are available in the folder: $PSScriptRoot\temp\"
+do { $myInput = (Read-Host 'Continue to use GIS Internals? (Y/N)').ToLower() } while ($myInput -notin @('y','n'))
+if ($myInput -ne 'y') {
+    Exit
+}
+
+Write-Host "Moving files..."
+Get-ChildItem GDAL_SDK\v141\bin\* -Force -Exclude !!!*.txt |  Remove-Item -force -recurse
+Get-ChildItem GDAL_SDK\v141\include\* -Force -Exclude !!!*.txt |  Remove-Item -force -recurse
+Get-ChildItem GDAL_SDK\v141\lib\* -Force -Exclude !!!*.txt |  Remove-Item -force -recurse
+Move-Item -Path .\temp\bin\* -Destination .\GDAL_SDK\v141\bin\win32\
+Move-Item -Path .\temp\include\* -Destination .\GDAL_SDK\v141\include\win32\
+Move-Item -Path .\temp\lib\* -Destination .\GDAL_SDK\v141\lib\win32\
+
+Write-Host "Success."
+Write-Host "SupportLibs.sln can now be built."


### PR DESCRIPTION
This change is intended to allow compilation with GDAL 3 and 2. I have only addressed the C++ compilation aspects of GDAL 3, not the projections or runtime. My knowledge of projections and GDAL isn't sufficient to do more.