### PR TITLE
Fix RawData read and write of SHP_POINTZ, z and m was flipped

### DIFF
--- a/src/COM classes/Shape.cpp
+++ b/src/COM classes/Shape.cpp
@@ -2339,7 +2339,7 @@ STDMETHODIMP CShape::ImportFromBinary(const VARIANT bytesArray, VARIANT_BOOL* re
 
 	auto data = (char*)p; // TODO: Fix compile warning
 
-	const int recordLength = gsl::narrow_cast<int>(bytesArray.parray->cbElements);
+	const int recordLength = gsl::narrow_cast<int>(bytesArray.parray->rgsabound->cElements);
 	const bool result = _shp->put_RawData(data, recordLength);
 	*retVal = result ? VARIANT_TRUE : VARIANT_FALSE;
 

--- a/src/Shapefile/ShapeWrapperCOM.cpp
+++ b/src/Shapefile/ShapeWrapperCOM.cpp
@@ -844,8 +844,8 @@ int* CShapeWrapperCOM::get_RawData()
 			}
 			else if (_shapeType == SHP_POINTZ)
 			{
-				gsl::at(_points, 0)->get_M(&ddata[2]);
-				gsl::at(_points, 0)->get_Z(&ddata[3]);
+				gsl::at(_points, 0)->get_Z(&ddata[2]);
+				gsl::at(_points, 0)->get_M(&ddata[3]);
 			}
 		}
 		return intdata;

--- a/src/Shapefile/ShapeWrapperPoint.cpp
+++ b/src/Shapefile/ShapeWrapperPoint.cpp
@@ -223,8 +223,8 @@ bool CShapeWrapperPoint::put_RawData(char* shapeData, int recordLength)
 	}
 	else if (shpType == SHP_POINTZ)
 	{
-		_m = ddata[2];
-		_z = ddata[3];
+		_z = ddata[2];
+		_m = ddata[3];
 	}
 
 	_initialized = true;
@@ -252,8 +252,8 @@ int* CShapeWrapperPoint::get_RawData()
 	}
 	else if (_shpType == SHP_POINTZ)
 	{
-		ddata[2] = _m;
-		ddata[3] = _z;
+		ddata[2] = _z;
+		ddata[3] = _m;
 	}
 
 	return intdata;


### PR DESCRIPTION
The reading and writing of Z and M values was flipped.
For SHP_POINTZ the Z comes before M.

Se Shapefile documentation: 
https://www.esri.com/content/dam/esrisites/sitecore-archive/Files/Pdfs/library/whitepapers/pdfs/shapefile.pdf
On page: 15  (Table 12 PointZ Record Contents).